### PR TITLE
Add previous handler to handler-list

### DIFF
--- a/src/ErrorFocus.php
+++ b/src/ErrorFocus.php
@@ -26,6 +26,9 @@ class ErrorFocus
             $list->addAdditionalErrorHandler($handler);
         }
 
-        set_error_handler($list);
+        $previousHandler = set_error_handler($list);
+	if (null !== $previousHandler) {
+	    $list->addAdditionalErrorHandler($previousHandler);
+	}
     }
 }


### PR DESCRIPTION
This change makes sure that a possibly set previous error handler will be added to the list of error-handlers. That way a previously set error-handler will not get lost.